### PR TITLE
Automatically default the cache parameter

### DIFF
--- a/gutenbergpy/gutenbergcache.py
+++ b/gutenbergpy/gutenbergcache.py
@@ -39,6 +39,7 @@ class GutenbergCache:
         download    = True  if kwargs.has_key('download') is False else kwargs['download']
         unpack      = True  if kwargs.has_key('unpack') is False else kwargs['unpack']
         parse       = True  if kwargs.has_key('parse') is False else kwargs['parse']
+        cache       = True  if kwargs.has_key('cache') is False else kwargs['cache']
         deleteTmp   = True  if kwargs.has_key('deleteTemp') is False else kwargs['deleteTemp']
 
         if path.isfile(GutenbergCacheSettings.CACHE_FILENAME) and refresh and cache_type == GutenbergCacheTypes.CACHE_TYPE_SQLITE:

--- a/gutenbergpy/gutenbergcache.py
+++ b/gutenbergpy/gutenbergcache.py
@@ -62,7 +62,7 @@ class GutenbergCache:
             result = parser.do()
             print('RDF PARSING took ' + str(time.time() - t0))
 
-            if kwargs['cache']:
+            if cache:
                 t0 = time.time()
                 cache = GutenbergCache.get_cache(cache_type)
                 cache.create_cache(result)


### PR DESCRIPTION
Automatically default the cache parameter to stop the `if kwargs['cache']:` line from getting a KeyError