### PR TITLE
Adapt textget to new Gutenberg urls

### DIFF
--- a/gutenbergpy/textget.py
+++ b/gutenbergpy/textget.py
@@ -109,11 +109,7 @@ LEGALESE_END_MARKERS = frozenset(("SERVICE THAT CHARGES FOR DOWNLOAD",))
 ##
 # adapted from https://github.com/c-w/Gutenberg/blob/master/gutenberg/acquire/text.py
 def get_text_dir_from_index(index):
-    str_etextno = str(index).zfill(2)
-    all_but_last_digit = list(str_etextno[:-1])
-    subdir_part = "/".join(all_but_last_digit)
-    subdir = "{0}/{1}".format(subdir_part, index)  # etextno not zfilled
-    return subdir
+    return f"files/{index}"
 
 
 ##
@@ -124,7 +120,7 @@ def _format_download_uri(index):
     Raises:
         UnknownDownloadUri: If no download location can be found for the text.
     """
-    uri_root = r'http://www.gutenberg.lib.md.us'
+    uri_root = r'https://www.gutenberg.org'
     extensions = ('.txt', '-8.txt', '-0.txt')
     for extension in extensions:
         path = get_text_dir_from_index(index)
@@ -134,10 +130,10 @@ def _format_download_uri(index):
             etextno=index,
             extension=extension)
         p = urlparse(uri)
-        conn = http.client.HTTPConnection(p.netloc)
+        conn = http.client.HTTPSConnection(p.netloc)
         conn.request('HEAD', p.path)
         resp = conn.getresponse()
-        if resp.status < 400 :
+        if resp.status < 400:
             return uri
     raise None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name= gutenbergpy
 author= Radu Angelescu
 author_email = raduangelescu@gmail.com
-version = 0.3.5
+version = 0.3.6
 description = Library to create and interogate local cache for Project Gutenberg
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
When running `gutenbergpy.textget.get_text_by_id(ebook_no)` there is an error 
```
TimeoutError: [Errno 60] Operation timed out
```

It is because hardcoded root path (http://www.gutenberg.lib.md.us) is not responding.

This PR is changing the root url to https://www.gutenberg.org and adapts textget.py module:
- change of root path
- adapt `get_path_for_index()`
- change `http.client.HTTPConnection` to `http.client.HTTPSConnection` as new site uses https


Before change running `test.py` ended with 
```
TimeoutError: [Errno 60] Operation timed out
```

After the change - works properly and prints downloaded text.