### PR TITLE
Fix to the book_id index computation

### DIFF
--- a/gutenbergpy/caches/sqlitecache.py
+++ b/gutenbergpy/caches/sqlitecache.py
@@ -8,6 +8,8 @@ import sqlite3
 import os
 
 
+print("Using overridden sqlitecache.py")
+
 ##
 # SQLite cache implementation
 class SQLiteCache(Cache):

--- a/gutenbergpy/caches/sqlitecache.py
+++ b/gutenbergpy/caches/sqlitecache.py
@@ -8,8 +8,6 @@ import sqlite3
 import os
 
 
-print("Using overridden sqlitecache.py")
-
 ##
 # SQLite cache implementation
 class SQLiteCache(Cache):

--- a/gutenbergpy/parse/rdfparser.py
+++ b/gutenbergpy/parse/rdfparser.py
@@ -12,8 +12,6 @@ from gutenbergpy.gutenbergcachesettings import GutenbergCacheSettings
 from gutenbergpy.utils                  import Utils
 
 
-print("Using overridden rdfparser.py")
-
 ##
 # The rdf parser
 # noinspection PyClassHasNoInit
@@ -39,7 +37,6 @@ class RdfParser:
         dirs  =  [d for d in listdir(GutenbergCacheSettings.CACHE_RDF_UNPACK_DIRECTORY) if not d.startswith("DELETE")]
         total = len(dirs)
 
-        print("Parsing RDF files, revised version...")
         for idx, dir in enumerate(dirs):
             if not str(dir).isdigit():
                 continue

--- a/gutenbergpy/parse/rdfparser.py
+++ b/gutenbergpy/parse/rdfparser.py
@@ -12,6 +12,8 @@ from gutenbergpy.gutenbergcachesettings import GutenbergCacheSettings
 from gutenbergpy.utils                  import Utils
 
 
+print("Using overridden rdfparser.py")
+
 ##
 # The rdf parser
 # noinspection PyClassHasNoInit
@@ -37,6 +39,7 @@ class RdfParser:
         dirs  =  [d for d in listdir(GutenbergCacheSettings.CACHE_RDF_UNPACK_DIRECTORY) if not d.startswith("DELETE")]
         total = len(dirs)
 
+        print("Parsing RDF files, revised version...")
         for idx, dir in enumerate(dirs):
             if not str(dir).isdigit():
                 continue
@@ -45,12 +48,13 @@ class RdfParser:
             file_path = path.join(GutenbergCacheSettings.CACHE_RDF_UNPACK_DIRECTORY,dir,'pg%s.rdf'%(dir))
             doc = etree.parse(file_path,etree.ETCompatXMLParser())
 
+            book_id = len(result.books)+1
             res = Fields.FIELD_COUNT * [-1]
             for idx_field, pt in enumerate(result.field_sets):
                 if not pt.needs_book_id():
                     res[idx_field] = pt.do(doc)
                 else:
-                    res[idx_field] = pt.do(doc,idx+1)
+                    res[idx_field] = pt.do(doc,book_id)
 
             gutenberg_book_id = int(dir)
 


### PR DESCRIPTION
TL;DR: Corrects computation of book_id to keep it in sync even if books don't end up getting added. 

In more detail if you need it ...

Hello, this is Anthony Francis, a colleague of Kenneth Moorman on the LCATS project https://github.com/xenotaur/LCATS . As Kenny mentioned in his email, we noticed some book_ids getting out of sync on higher numbered files in the corpus. We debugged this to the book_id being computed from the index, which gets out of sync if books are not added. This small change computes book_id based on the books that have been added, keeping it in sync. This was tested in a development branch of the LCATS project and seems to work.

We will send the more extensive PR regarding authors separately, as we thought this change was relatively noncontroversial and easier to grok in its own PR.

Thanks so much for considering our PR!